### PR TITLE
[WIP] Initial environment setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+group :development do
+  gem 'rubocop'
+end
+
+gem 'activesupport', '~> 5.2.3'
+gem 'inspec-bin'
+gem 'nokogiri', '~> 1.8'
+gem 'pry-byebug'
+gem 'rake', '~> 12.3', '>= 12.3.1'
+gem 'winrm-elevated'

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,356 @@
+#!/usr/bin/env rake
+# frozen_string_literal: true
+
+require 'rake/testtask'
+require 'rubocop/rake_task'
+require_relative 'test/integration/configuration/config'
+require_relative 'tasks/check_json_results'
+require 'aws-sdk-ec2'
+require 'open3'
+require 'winrm'
+require 'winrm-fs'
+require 'winrm-elevated'
+
+INTEGRATION_DIR = File.join(File.dirname(__FILE__), 'test', 'integration')
+TERRAFORM_DIR = File.join(INTEGRATION_DIR, 'build')
+TF_VAR_FILE_NAME = 'exchange2016-rpg.tfvars.json'
+TF_VAR_FILE = File.join(TERRAFORM_DIR, TF_VAR_FILE_NAME)
+TF_PLAN_FILE = 'exchange2016-rpg.plan'
+PROFILE_ATTRIBUTES = 'exchange2016-rpg-attributes.yaml'
+REMEDIATION_PROFILE = '../compliance-remediation/test/CIS_Microsoft_Exchange_Server_2016_v_1_0_0_cookbook'
+INSPEC_PROFILE = '../cis-exchange2016-benchmark'
+
+# Rubocop
+desc 'Run Rubocop lint checks'
+task :rubocop do
+  RuboCop::RakeTask.new
+end
+
+# lint the project
+desc 'Run robocop linter'
+task lint: [:rubocop]
+
+# run tests
+task default: [:lint, 'rpg:check']
+
+namespace :rpg do
+  task :tf_dir do
+    Dir.chdir(TERRAFORM_DIR)
+  end
+
+  # run inspec check to verify that the profile is properly configured
+  task :check do
+    dir = File.join(File.dirname(__FILE__))
+    sh("bundle exec inspec check #{dir}")
+    # run inspec check on the sample profile to ensure all resources are loaded okay
+    sh('bundle exec inspec check .')
+  end
+
+  def configure(variables_file, attributes_file)
+    puts '----> Generating terraform and inspec variable files'
+    Config.store_json(variables_file)
+    Config.store_yaml(attributes_file)
+    Config.config
+  end
+
+  task init_workspace: [:tf_dir] do
+    puts '----> Initializing terraform workspace'
+    # Initialize terraform workspace
+    cmd = format('terraform init')
+    sh(cmd)
+  end
+
+  # This is a standalone task for convenience that only updates configuration for InSpec and Terraform.
+  task :configure do
+    puts '----> Updating configuration settings'
+    configure(TF_VAR_FILE_NAME, PROFILE_ATTRIBUTES)
+  end
+
+  task plan_integration_tests: %i[tf_dir init_workspace] do
+    if File.exist?(TF_VAR_FILE)
+      puts '----> Previous run not cleaned up - running cleanup...'
+      Rake::Task['rpg:cleanup_integration_tests'].execute
+    end
+    configure(TF_VAR_FILE_NAME, PROFILE_ATTRIBUTES)
+    puts '----> Generating the Plan'
+    # Create the plan that can be applied to AWS
+    cmd = format('terraform plan -var-file=%<var_file>s -out %<plan_file>s', var_file: TF_VAR_FILE_NAME, plan_file: TF_PLAN_FILE)
+    sh(cmd)
+  end
+
+  task setup_integration_tests: %i[tf_dir plan_integration_tests] do
+    puts '----> Applying the plan'
+    # Apply the plan
+    cmd = format('terraform apply %<plan_file>s', plan_file: TF_PLAN_FILE)
+    sh(cmd)
+    puts '----> Adding terraform outputs to InSpec variable file'
+    Config.update_yaml(PROFILE_ATTRIBUTES)
+    attributes = YAML.load_file(File.join(TERRAFORM_DIR, PROFILE_ATTRIBUTES))
+
+    puts "----> Writing SSH key file #{attributes[:ssh_key_name]} for VM"
+    File.open(File.join(File.dirname(__FILE__), attributes[:ssh_key_name]), 'w') do |f|
+      f.write(attributes[:ssh_private_key_pem])
+    end
+    sh("chmod 400 #{File.join(File.dirname(__FILE__), 'ssh-key-*')}")
+
+    Rake::Task['rpg:run_precursor_scripts'].execute
+
+    puts "----> Allocating Elastic IP to Exchange Node"
+    exch_public_ip = assign_elastic_ip
+    attributes[:instance_ip] = {}
+    attributes[:instance_ip] = exch_public_ip
+    File.open(File.join(TERRAFORM_DIR, PROFILE_ATTRIBUTES), "w"){ |f| YAML.dump(attributes, f) }
+
+    puts "Exchange Server Public IP - " + exch_public_ip
+
+    username = attributes[:domain_netbios_name] + "\\" + attributes[:instance_username]
+    password = attributes[:instance_password]
+
+    require 'pry'; binding.pry
+
+    script_target = ENV['SETUP_SCRIPT'] || attributes[:setup_script]
+    raise "Could not find script file: #{script_target}" unless File.exist?(script_target)
+
+    puts "---> Installing Chef Client and Running Setup Script"
+    counter = 0
+    status = {}
+    while counter < 20
+      conn = winrm_connection(attributes[:instance_ip], attributes[:instance_username], attributes[:instance_password])
+      file_manager = WinRM::FS::FileManager.new(conn)
+      sleep(60)
+      file_manager.upload(script_target, "C:/#{script_target}")
+      sleep(60)
+      conn.shell(:elevated) do |shell|
+        shell.username =  attributes[:domain_netbios_name] + "\\" + attributes[:instance_username]
+        shell.password = attributes[:instance_password]
+        output = shell.run("C:/#{script_target}") do |stdout, stderr|
+          STDOUT.print stdout
+          STDERR.print stderr
+        end
+        status = 'success' if output.exitcode.zero?
+        puts "The script exited with exit code #{output.exitcode}"
+      end
+      break if status == 'success'
+
+      sleep(10)
+      counter += 1
+    end
+
+    counter = 0
+    puts '---> Waiting for bootstrap to finish...'
+    while counter < 20
+      cmd = "inspec detect -t winrm://#{exch_public_ip} --user='#{username}' --password='#{password}'"
+      stdout, stderr, status = Open3.capture3(cmd)
+      puts stdout
+      puts stderr
+      break if status.success?
+
+      sleep(10)
+      counter += 1
+    end
+    puts 'Instances responding on WinRM...'
+  end
+
+  task :run_precursor_scripts do
+    puts "----> Stopping unused instances"
+    stop_unused_instances
+
+    puts '----> Modifying security group to allow remote connection'
+    modify_security_groups
+
+    puts '----> Configuring route table of Exchange Server subnet to allow RDP connection'
+    allow_traffic_on_exchange_node
+  end
+
+  def modify_security_groups
+    ec2_client = Aws::EC2::Client.new(region: 'eu-north-1')
+    exchange_vpc = ec2_client.describe_vpcs(filters: [{ name: 'tag:Name', values: ['exchange-stack*'] }])
+
+    if exchange_vpc.vpcs.empty?
+      puts "FAILED - No VPC found in Exchange Stack"
+    else
+      vpc_id = exchange_vpc[0][0].vpc_id
+      vpc_domainmembers_sgs = ec2_client.describe_security_groups(filters: [{ name: 'vpc-id', values: [vpc_id] }, { name: 'group-name', values: ['exchange-stack-ADStack-*-DomainMembers*']} ])
+      sg_id = vpc_domainmembers_sgs.security_groups[0][:group_id]
+
+      begin
+        ec2_client.authorize_security_group_ingress({group_id: sg_id, ip_permissions: [{ ip_protocol: "tcp", from_port: 3389, to_port: 3389, ip_ranges: [{ cidr_ip: "0.0.0.0/0" }]}]})
+        ec2_client.authorize_security_group_ingress({group_id: sg_id, ip_permissions: [{ ip_protocol: "tcp", from_port: 5985, to_port: 5985, ip_ranges: [{ cidr_ip: "0.0.0.0/0" }]}]})
+        puts "SUCCESS - RDP/WinRM traffic opened on Exchange Stack"
+      rescue Aws::EC2::Errors::InvalidPermissionDuplicate
+        puts "SKIPPED - RDP/WinRM rule already exists on Exchange Stack"
+      end
+    end
+  end
+
+  def allow_traffic_on_exchange_node
+    ec2_client = Aws::EC2::Client.new(region: 'eu-north-1')
+
+    exchange_instance = ec2_client.describe_instances(filters: [{ name: 'tag:Name', values:['ExchNodeMain']}])
+
+    exchange_subnet_id = exchange_instance.reservations[0].instances[0].subnet_id
+    exchange_vpc_id = exchange_instance.reservations[0].instances[0].vpc_id
+
+    exchange_igw = ec2_client.describe_internet_gateways(filters: [{ name: 'attachment.vpc-id', values:[exchange_vpc_id]}])
+    igw_id = exchange_igw.internet_gateways[0].internet_gateway_id
+
+    exchange_route_tables = ec2_client.describe_route_tables(filters: [{ name: 'association.subnet-id', values:[exchange_subnet_id]}])
+    route_table_id = exchange_route_tables.route_tables[0].associations[0].route_table_id
+
+    ec2_client.replace_route({route_table_id: route_table_id, destination_cidr_block: '0.0.0.0/0', gateway_id: igw_id})
+
+    puts "SUCCESS - Route Table gateway modified on Exchange Node"
+  end
+
+  def release_elastic_ip
+    ec2_client = Aws::EC2::Client.new(region: 'eu-north-1')
+    attributes = YAML.load_file(File.join(TERRAFORM_DIR, PROFILE_ATTRIBUTES))
+
+    ip = attributes[:instance_ip]
+
+    unless ip.nil?
+      elastic_ip = ec2_client.describe_addresses(public_ips: [ip])
+      ec2_client.disassociate_address(public_ip: ip)
+
+      ec2_client.release_address({ allocation_id: elastic_ip.addresses[0].allocation_id })
+    end
+  end
+
+  def assign_elastic_ip
+    ec2_client = Aws::EC2::Client.new(region: 'eu-north-1')
+
+    exchange_instance = ec2_client.describe_instances(filters: [{ name: 'tag:Name', values:['ExchNodeMain']}])
+    exchange_instance_id = exchange_instance.reservations[0].instances[0].instance_id
+
+    puts "Allocating the address for the instance..."
+    elastic_ip = ec2_client.allocate_address({domain: "vpc"})
+
+    puts "Associating the address with the instance..."
+    ec2_client.associate_address({allocation_id: elastic_ip.allocation_id, instance_id: exchange_instance_id})
+
+    elastic_ip.public_ip
+  end
+
+  def stop_unused_instances
+    ec2 = Aws::EC2::Resource.new(region: 'eu-north-1')
+    ec2.instances({filters: [{name: 'tag:Name', values: ['Stop*']}]}).each do |instance|
+      case instance.state.code
+      when 48  # terminated
+        puts "#{instance.id} is terminated, so you cannot stop it"
+      when 64  # stopping
+        puts "#{instance.id} is stopping, so it will be stopped in a bit"
+      when 80  # stopped
+        puts "#{instance.id} is already stopped"
+      else
+        instance.stop
+      end
+    end
+  end
+
+  def winrm_connection(ip, username, password)
+    WinRM::Connection.new({
+                            endpoint: "http://#{ip}:5985/wsman",
+                            user: username,
+                            password: password
+                          })
+  end
+
+  task :run_script do
+    attributes = YAML.load_file(File.join(TERRAFORM_DIR, PROFILE_ATTRIBUTES))
+    script_target = ENV['EXE_SCRIPT'] || attributes[:execute_script]
+    raise "Could not find script file: #{script_target}" unless File.exist?(script_target)
+
+    counter = 0
+    status = {}
+    while counter < 20
+      conn = winrm_connection(attributes[:instance_ip], attributes[:instance_username], attributes[:instance_password])
+      file_manager = WinRM::FS::FileManager.new(conn)
+      sleep(60)
+      file_manager.upload(script_target, "C:/#{script_target}")
+      sleep(60)
+      conn.shell(:elevated) do |shell|
+        shell.username =  attributes[:domain_netbios_name] + "\\" + attributes[:instance_username]
+        shell.password = attributes[:instance_password]
+        output = shell.run("C:/#{script_target}") do |stdout, stderr|
+          STDOUT.print stdout
+          STDERR.print stderr
+        end
+        status = 'success' if output.exitcode.zero?
+        puts "The script exited with exit code #{output.exitcode}"
+      end
+    break if status == 'success'
+
+    sleep(10)
+    counter += 1
+    end
+  end
+
+  task :run_scan do
+    puts '----> Running InSpec tests'
+    reporter_name_suffix = ENV['INSPEC_REPORT_NAME'] || 'inspec-output'
+    attributes = YAML.load_file(File.join(TERRAFORM_DIR, PROFILE_ATTRIBUTES))
+    # take profile target from env before checking attributes
+    profile_target = INSPEC_PROFILE || attributes['inspec_profile']
+
+    reporter_name = "#{reporter_name_suffix}"
+    cmd = 'bundle exec inspec exec %s -t winrm://%s@%s --password="%s" --input-file %s/build/%s --reporter cli json:results/%s.json html:%s.html --chef-license=accept-silent'
+    cmd += '; rc=$?; if [ $rc -eq 0 ] || [ $rc -eq 101 ] || [ $rc -eq 100 ]; then exit 0; else exit 1; fi'
+    cmd = format(cmd, profile_target, attributes[:instance_username], attributes[:instance_ip], attributes[:instance_password], INTEGRATION_DIR, PROFILE_ATTRIBUTES, reporter_name, reporter_name)
+    sh(cmd)
+  end
+
+  task :run_remediation do
+    attributes = YAML.load_file(File.join(TERRAFORM_DIR, PROFILE_ATTRIBUTES))
+    remediation_target = REMEDIATION_PROFILE || attributes[:remediation_profile]
+    raise "Could not find remediation profile: #{remediation_target}" unless remediation_target
+
+    cookbook_run_list = "remediation_#{remediation_target.split('/').last.split('_cookbook')[0].downcase}"
+
+    counter = 0
+    status = {}
+    while counter < 20
+      conn = winrm_connection(attributes[:instance_ip], attributes[:instance_username], attributes[:instance_password])
+      file_manager = WinRM::FS::FileManager.new(conn)
+      sleep(10)
+      puts "----> Copying remediation profile"
+      file_manager.upload(remediation_target, 'C:/remediation')
+      file_manager.upload("#{remediation_target}/cookbooks/remediation_cis_microsoft_exchange_server_2016_v_1_0_0/files/default/CIS_Microsoft_Exchange_Server_2016_v_1_0_0/", "C:/remediation/cookbooks/remediation_cis_microsoft_exchange_server_2016_v_1_0_0/files/default/")
+      sleep(10)
+      conn.shell(:elevated) do |shell|
+        shell.username = attributes[:instance_username]
+        shell.password = attributes[:instance_password]
+        output = shell.run("cd C:/remediation/cookbooks/#{cookbook_run_list}; chef-client -z -l info --chef-license accept-silent -o #{cookbook_run_list}") do |stdout, stderr|
+          STDOUT.print stdout
+          STDERR.print stderr
+        end
+        puts "The script exited with exit code #{output.exitcode}"
+        status = 'success' if output.exitcode.zero?
+        puts '----> Retrieving remediation outputs'
+        file_manager.download('$env:TEMP/remediation_outputs.yaml', "remediation_outputs.yaml")
+      end
+      break if status == 'success'
+
+      sleep(10)
+      counter += 1
+    end
+  end
+
+  task cleanup_integration_tests: [:tf_dir] do
+    puts '----> Cleanup'
+    release_elastic_ip
+    cmd = 'terraform destroy -force -var-file=%s '
+    cmd += ' || true' if ENV['CLEANUP_TRAP_NON_ZERO_EXIT']
+    cmd = format(cmd, TF_VAR_FILE_NAME)
+    sh(cmd) if File.exist?(TF_VAR_FILE)
+    sh("rm -f #{File.join(File.dirname(__FILE__), 'ssh-key-*')}")
+  end
+
+  task :full_test do
+    Rake::Task['rpg:setup_integration_tests'].invoke
+    Rake::Task['rpg:run_script'].invoke
+    Rake::Task['rpg:run_scan'].invoke
+    Rake::Task['rpg:run_remediation'].invoke
+    Rake::Task['rpg:run_scan'].invoke
+    Rake::Task['rpg:cleanup_integration_tests'].invoke
+  end
+end

--- a/scripts/break_exchange.ps1
+++ b/scripts/break_exchange.ps1
@@ -1,0 +1,59 @@
+Set-ExecutionPolicy RemoteSigned
+# Connect to Exchange Server
+Add-PSSnapin Microsoft.Exchange.Management.PowerShell.SnapIn;
+# 1.2
+Set-TransportConfig -MaxReceiveSize 20MB
+# 1.3
+Set-SenderIDConfig -Enabled $false
+# 1.4
+ Set-SendConnector ExampleSendConnector -DNSRoutingEnabled $false -SmartHosts exchexample.com
+# 1.5
+Set-SenderFilterConfig -Enabled $false
+# 1.6
+Set-SenderReputationConfig -SenderBlockingEnabled $false -OpenProxyDetectionEnabled $true
+# 1.8
+Set-SendConnector -identity ExampleSendConnector -IgnoreSTARTTLS: $true
+# 1.9
+Set-PopSettings -LoginType PlainTextLogin
+# 1.13
+Set-TransportService ExchNodeMain -MessageTrackingLogEnabled $false
+# 1.14
+Set-TransportService ExchNodeMain -MessageTrackingLogEnabled $false
+# 1.15
+Set-ImapSettings -LoginType PlainTextLogin
+# 1.16
+Set-TransportService ExchNodeMain -ConnectivityLogEnabled $false
+# 1.17
+Set-TransportConfig -MaxSendSize "5MB"
+# 2.1
+Set-MailboxDatabase "DB1" -IssueWarningQuota "1.7 GB"
+# 2.3
+Set-MailboxDatabase "DB1" -ProhibitSendQuota "1.95 GB"
+# 2.4
+Set-Mailboxdatabase "DB1" -MailboxRetention 20.00:00:00
+# 2.8
+Set-MobileDeviceMailboxPolicy default -PasswordExpiration 180
+# 2.9
+Set-MobileDeviceMailboxPolicy default -MinPasswordLength 2
+# 2.13
+Set-UMMailboxPolicy -id ExampleUMMailboxPolicy -AllowPinlessVoiceMailAccess $true
+# 2.14
+Set-MailboxDatabase -Identity DB1 -DeletedItemRetention 21
+# 2.18
+Set-MobileDeviceMailboxPolicy -Identity Default -AlphanumericPasswordRequired $false
+# 2.19
+Set-RpcClientAccess -Server ExchNodeMain -EncryptionRequired $false
+# 3.1
+Set-AdminAuditLogConfig -AdminAuditLogCmdlets "None"
+# 3.3
+Set-ExecutionPolicy Unrestricted
+# 3.4
+Set-AdminAuditLogConfig -AdminAuditLogEnabled $False
+# 3.5
+Set-RemoteDomain -Identity Default -AutoReplyEnabled $true
+# 3.9
+Set-RemoteDomain -Identity Default -AutoForwardEnabled $true
+# 3.10
+Set-OWAVirtualDirectory -identity "owa (Default Web Site)" -SMimeEnabled $false
+# 3.11
+Set-AdminAuditLogConfig -AdminAuditLogEnabled $false

--- a/scripts/exchange_setup.ps1
+++ b/scripts/exchange_setup.ps1
@@ -1,0 +1,14 @@
+Set-ExecutionPolicy RemoteSigned
+
+Write-Host "Install Chef Client for remediation"
+. { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install
+
+Add-PSSnapin Microsoft.Exchange.Management.PowerShell.SnapIn;
+
+New-SendConnector -Internet -Name ExampleSendConnector -AddressSpaces exchexample.com;
+
+New-ReceiveConnector -Name ExampleReceiveConnector -Usage Custom -Bindings 10.0.0.0:16 -RemoteIPRanges 192.168.0.1-192.168.0.24;
+
+New-UMDialPlan -Name ExampleUMDialPlan -NumberOfDigitsInExtension 4 -CountryOrRegionCode 44;
+
+New-UMMailboxPolicy -Name ExampleUMMailboxPolicy -UMDialPlan ExampleUMDialPlan;

--- a/scripts/parse_results.rb
+++ b/scripts/parse_results.rb
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'optparse'
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = 'Usage: create human readable inspec results file [options]'
+  opts.on('-lLOG_NAME', '--log_name=LOG_NAME', 'The name of the inspec json log file') do |l|
+    options[:log_name] = l
+  end
+end.parse!
+abort('Provide inspec json results file name!') unless options[:log_name]
+
+puts "reading file: results/#{options[:log_name]}.json"
+file = File.read("results/#{options[:log_name]}.json")
+content = JSON.parse(file)
+control_results = {}
+content['profiles'].each do |profile|
+  profile['controls'].each do |control|
+    id = control['id']
+    result = control['results'].map { |res| res['status'] }
+    control_results[id] = if result.include?('failed')
+                            'failed'
+                          elsif result.include?('passed')
+                            'passed'
+                          elsif result.include?('skipped')
+                            'skipped'
+                          else
+                            'excluded'
+                          end
+  end
+end
+
+def write_results(control_results, out_file, type)
+  out_file.puts("#{type.capitalize} controls:")
+  if control_results.value?(type)
+    controls = control_results.select { |_, value| value == type }.keys
+    out_file.puts(controls.sort)
+    out_file.puts("Total #{type} controls: #{controls.count}", '')
+  else
+    out_file.puts("Total #{type} controls: 0\n", '')
+  end
+end
+
+out_file = File.new("results/#{options[:log_name]}.txt", 'w')
+write_results(control_results, out_file, 'passed')
+write_results(control_results, out_file, 'skipped')
+write_results(control_results, out_file, 'failed')
+write_results(control_results, out_file, 'excluded')

--- a/test/integration/build/main.tf
+++ b/test/integration/build/main.tf
@@ -1,0 +1,79 @@
+terraform {
+  required_version = "~> 0.12"
+}
+
+# Configure variables
+variable "aws_region" {}
+variable "aws_profile" {}
+
+# just to stop warnings
+variable "execute_script" {}
+variable "setup_script" {}
+variable "remediation_profile" {}
+variable "inspec_profile" {}
+
+variable "ssh_key_name" {}
+
+variable "instance_password" {}
+
+provider "aws" {
+  version = "~> 2.7"
+  region = var.aws_region
+  profile = var.aws_profile
+  shared_credentials_file = "~/.aws/credentials"
+}
+
+resource "aws_key_pair" "generated_key" {
+  key_name = var.ssh_key_name
+  public_key = tls_private_key.priv_key.public_key_openssh
+}
+
+resource "tls_private_key" "priv_key" {
+  algorithm = "RSA"
+  rsa_bits = 4096
+}
+
+resource "aws_cloudformation_stack" "exchange2016" {
+  name = "exchange-stack"
+
+  parameters = {
+    AvailabilityZones = "eu-north-1a, eu-north-1b",
+    ADServer1NetBIOSName = "DC1",
+    ADServer1InstanceType = "t3.large"
+    ADServer2InstanceType = "t3.large"
+    ADServer2NetBIOSName = "StopDC2",
+    DomainAdminUser = "ExchangeAdmin",
+    DomainAdminPassword = var.instance_password,
+    DomainDNSName = "exchexample.com",
+    DomainNetBIOSName = "exchexample",
+//    EdgeInstanceType = "t3.large",
+//    EdgeNode1NetBIOSName = "EdgeNodeMain",
+//    EdgeNode2NetBIOSName = "StopEdgeNode2",
+    ExchangeNode1NetBIOSName = "ExchNodeMain",
+    ExchangeNode2NetBIOSName = "StopExchNode2",
+    ExchangeNodeInstanceType = "m5.xlarge",
+    ExchangeServerVersion = "2016",
+    FileServerInstanceType = "t3.small",
+    FileServerNetBIOSName = "StopFileServer",
+//    IncludeEdgeTransportRole = "yes",
+    KeyPairName = var.ssh_key_name,
+    QSS3BucketName = "aws-quickstart",
+    QSS3BucketRegion = "us-east-1",
+    QSS3KeyPrefix = "quickstart-microsoft-exchange/",
+    RDGWCIDR = "0.0.0.0/0"
+    RDGWInstanceType = "m5.large"
+  }
+
+  template_url = "https://aws-quickstart.s3.amazonaws.com/quickstart-microsoft-exchange/templates/exchange-master.template"
+  capabilities = ["CAPABILITY_IAM"]
+  timeout_in_minutes = "300"
+  disable_rollback = "true"
+
+  timeouts {
+    create = "240m"
+  }
+
+  tags = {
+    Name = "Exchange2016Stack"
+  }
+}

--- a/test/integration/build/outputs.tf
+++ b/test/integration/build/outputs.tf
@@ -1,0 +1,19 @@
+output "ssh_public_key" {
+  value = aws_key_pair.generated_key.public_key
+}
+
+output "ssh_private_key" {
+  value = tls_private_key.priv_key
+}
+
+output "ssh_private_key_pem" {
+  value = tls_private_key.priv_key.private_key_pem
+}
+
+output "instance_username" {
+  value = aws_cloudformation_stack.exchange2016.parameters.DomainAdminUser
+}
+
+output "domain_netbios_name" {
+  value = aws_cloudformation_stack.exchange2016.parameters.DomainNetBIOSName
+}

--- a/test/integration/configuration/config.rb
+++ b/test/integration/configuration/config.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# Configuration helper for Exchange 2016 & Inspec
+# - Terraform expects a JSON variable file
+# - Inspec expects a YAML attribute file
+# This allows to store all transient parameters in one place.
+# If any of the @config keys are exported as environment variables in uppercase, these take precedence.
+require 'json'
+require 'yaml'
+
+module Config
+  # helper method for adding random strings
+  def self.add_random_string(length = 15)
+    (0...length).map { rand(65..90).chr }.join.downcase.to_s
+  end
+
+  # Config for terraform / inspec in the below hash
+  @config = {
+    # Generic AWS resource parameters
+    aws_region: 'eu-north-1',
+    aws_profile: 'partner-engineering',
+    ssh_key_name: "ssh-key-#{add_random_string}",
+    execute_script: 'scripts/break_exchange.ps1',
+    setup_script: 'scripts/exchange_setup.ps1',
+    remediation_profile: '', # set to copy across the remediation cookbook and run it
+    inspec_profile: '', # set to a profile for target mode against host
+    instance_password: 'ExchPW123!'
+  }
+
+  def self.config
+    @config
+  end
+
+  # This method ensures any environment variables take precedence.
+  def self.update_from_environment
+    @config.each { |k, v| @config[k] = ENV[k.to_s.upcase] || v }
+  end
+
+  # Create JSON for terraform
+  def self.store_json(file_name = 'aws-inspec.tfvars')
+    update_from_environment
+    File.open(File.join(File.dirname(__FILE__), '..', 'build', file_name), 'w') do |f|
+      f.write(@config.to_json)
+    end
+  end
+
+  # Create YAML for inspec
+  def self.store_yaml(file_name = 'aws-inspec-attributes.yaml')
+    update_from_environment
+    File.open(File.join(File.dirname(__FILE__), '..', 'build', file_name), 'w') do |f|
+      f.write(@config.to_yaml)
+    end
+  end
+
+  def self.get_tf_output_vars(file_name = 'outputs.tf')
+    # let's assume that all lines starting with 'output' contain the desired target name
+    # (brittle but this way we don't need to preserve a list)
+    outputs = []
+    outputs_file = File.join(File.dirname(__FILE__), '..', 'build', file_name)
+    File.read(outputs_file).lines.each do |line|
+      next if !line.start_with?('output')
+      outputs += [line.sub(/^output \"/, "").sub(/\" {\n/, '')]
+    end
+    outputs
+  end
+
+  def self.update_yaml(file_name = 'aws-inspec-attributes.yaml')
+    build_dir = File.join(File.dirname(__FILE__), '..', 'build')
+    contents = YAML.load_file(File.join(build_dir, file_name))
+    outputs = get_tf_output_vars
+    outputs.each do |tf|
+      # also assuming single values here
+      value = `cd #{build_dir} && terraform output #{tf}`.strip
+      contents[tf.to_sym] = value
+    end
+    File.open(File.join(File.dirname(__FILE__), '..', 'build', file_name), 'w') do |f|
+      f.write(contents.to_yaml)
+    end
+  end
+end


### PR DESCRIPTION
Signed-off-by: Dylan Martin <dmartin@chef.io>

Work In Progress!

- Rakefile setup for full CI, includes methods that are required during setup to assign an Elastic IP to the Exchange Server for direct connection
- This setup uses a CloudFormation template which provides the full architecture required for an exchange setup, however it supplies two setups, so one must be stopped upon initialisation finishing, which there is a function for